### PR TITLE
fix: line-width not dependant on screen width

### DIFF
--- a/theme.css
+++ b/theme.css
@@ -5,9 +5,7 @@
 
 
 .theme-dark {
-
-  --file-line-width: 52vw;
-
+  
   --color-base-00: hsl(205, 23%, 10%);
   /* background-primary */
   --color-base-10: hsl(205, 23%, 8%);


### PR DESCRIPTION
This makes it so much more viewable on mobile devices using the default stylings for line width rather than explicitly defining it here. On other devices like laptops, there is no difference.

| Device | before | after |
| --- | --- | --- |
| iPhone | <img src="https://forum.obsidian.md/uploads/default/optimized/3X/8/d/8d26ffa1d2ee9fa05493b26521d3147b87826384_2_346x750.jpeg" alt="before" width="400px"> | <img src="https://github.com/sergey900553/obsidian_dekurai_theme/assets/37216503/b80245bb-c245-4f23-b3f7-7a06c54596a6" alt="after" width="400px"> |
| Laptop | ![image](https://github.com/sergey900553/obsidian_dekurai_theme/assets/37216503/b9dd75bc-c727-425e-bbb2-4166d58d130b) | ![image](https://github.com/sergey900553/obsidian_dekurai_theme/assets/37216503/90628d6b-cec8-44d0-985d-5b2aa4a3dcb2) |
